### PR TITLE
add AGENT_IP and AGENT_PORT environment variables

### DIFF
--- a/00_checkinstall.sh
+++ b/00_checkinstall.sh
@@ -19,5 +19,11 @@ if [ ! -d "$AGENT_DIR" ]; then
     fi
     if [ ! -z "$AGENT_PORT" ]; then 
         echo "ownPort=${AGENT_PORT}" >> $AGENT_DIR/conf/buildAgent.properties
-    fi            
+    fi
+    if [ ! -z "$AGENT_TOKEN" ]; then 
+        echo "teamcity.magic.authorizationToken=${AGENT_TOKEN}" >> $AGENT_DIR/conf/buildAgent.properties
+    fi 
+    if [ ! -z "$AGENT_NAME" ]; then 
+        echo "name=${AGENT_NAME}" >> $AGENT_DIR/conf/buildAgent.properties
+    fi 
 fi

--- a/00_checkinstall.sh
+++ b/00_checkinstall.sh
@@ -14,4 +14,10 @@ if [ ! -d "$AGENT_DIR" ]; then
     echo "workDir=/data/work" >> $AGENT_DIR/conf/buildAgent.properties
     echo "tempDir=/data/temp" >> $AGENT_DIR/conf/buildAgent.properties
     echo "systemDir=../system" >> $AGENT_DIR/conf/buildAgent.properties
+    if [ ! -z "$AGENT_IP" ]; then 
+        echo "ownAddress=${AGENT_IP}" >> $AGENT_DIR/conf/buildAgent.properties
+    fi
+    if [ ! -z "$AGENT_PORT" ]; then 
+        echo "ownPort=${AGENT_PORT}" >> $AGENT_DIR/conf/buildAgent.properties
+    fi            
 fi


### PR DESCRIPTION
This is necessary in case when the teamcity server and teamcity agent running on different hosts.
